### PR TITLE
리프레시토큰 저장 수정

### DIFF
--- a/src/services/login/login-api.js
+++ b/src/services/login/login-api.js
@@ -1,3 +1,5 @@
+let refreshTokenMemory = null;
+
 export const login = async ({ username, password }) => {
     try {
         const response = await fetch(
@@ -23,8 +25,9 @@ export const login = async ({ username, password }) => {
 
         // 로컬스토리지 토큰 저장
         localStorage.setItem("accessToken", access);
-        localStorage.setItem("refreshToken", refresh);
         localStorage.setItem("userInfo", JSON.stringify(user));
+
+        refreshTokenMemory = refresh;
 
         const previousPage = document.referrer;
 


### PR DESCRIPTION
## 🐞 버그 내용
- 리프레시 토큰 로컬스토리지에 저장됐던거를 메모리로 관리
## 🔧 수정 사항
- 전역변수에 null값으로 주고 응답으로 받은 json의 refresh를 전역에 저장된 변수에 넣음
- >> 탭을 닫으면 메모리 사라짐